### PR TITLE
Add prioritization of matrix init hooks

### DIFF
--- a/lib/matrix.lua
+++ b/lib/matrix.lua
@@ -188,12 +188,16 @@ function ModMatrix:bang_all()
     self.bang_deferred = nil
 end
 
-function ModMatrix:add_post_init_hook(f)
-    table.insert(self.post_init_hooks, f)
+function ModMatrix:add_post_init_hook(f, priority)
+    priority = priority or 0
+    table.insert(self.post_init_hooks, {fn = f, priority = priority})
 end
 
 function ModMatrix:call_post_init_hooks()
-    for _, f in ipairs(self.post_init_hooks) do f() end
+    table.sort(self.post_init_hooks, function(a,b)
+        return a.priority > b.priority
+    end)
+    for _, f in ipairs(self.post_init_hooks) do f.fn() end
 end
 
 function ModMatrix:defer_bang(param_id, tier)


### PR DESCRIPTION
I wanted to be sure the [funkit](https://github.com/eethann/funkit) init methods were called after toolkit, so I had access to the toolkit lattice and could be sure funkit's tick fns would execute after. Simplest way seemed to be something like this, should be non-breaking.

Priority is ordered such that 0 is default priority, greater values are executed earlier. E.g. priority 10 will be executed before the defaults, then the 0s, then any negative priorities. I used negative priorities in funkit.